### PR TITLE
Enhance desktop watchdog reliability and add operations dashboard

### DIFF
--- a/src/main/java/desk/App.java
+++ b/src/main/java/desk/App.java
@@ -8,6 +8,21 @@ public final class App {
         boolean headless = false;
         for (String a : args) if ("--headless".equalsIgnoreCase(a)) headless = true;
 
+        // Allow watchdog / service scripts to force headless mode via env var so
+        // a manifest "java -jar" launch never surprises users with the GUI.
+        if (!headless) {
+            String forced = System.getenv("APACHE_BRIDGE_FORCE_HEADLESS");
+            if (forced != null && !forced.isBlank()) {
+                headless = "1".equals(forced.trim())
+                        || "true".equalsIgnoreCase(forced.trim())
+                        || "yes".equalsIgnoreCase(forced.trim());
+            }
+        }
+
+        if (headless) {
+            System.setProperty("java.awt.headless", "true");
+        }
+
         // Normal mode (GUI)
         if (!headless) {
             // Just show the control panel; installer is a separate JAR now.

--- a/src/main/java/desk/AutoStartManager.java
+++ b/src/main/java/desk/AutoStartManager.java
@@ -63,8 +63,8 @@ public final class AutoStartManager {
                         "-NoProfile", "-ExecutionPolicy", "Bypass",
                         "-File", script.toString());
             } else {
-                // Run via bash to inherit interactive PATH on Linux/macOS
-                pb = new ProcessBuilder("bash", "-lc", "\"" + script.toString().replace("\"","\\\"") + "\"");
+                // Execute the script directly via bash to avoid shell quoting issues
+                pb = new ProcessBuilder("bash", script.toString());
             }
             pb.redirectErrorStream(true);
             pb.start();

--- a/src/main/java/desk/Diagnostics.java
+++ b/src/main/java/desk/Diagnostics.java
@@ -1,0 +1,212 @@
+package desk;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Runs cross-cutting health checks so the GUI can show actionable diagnostics
+ * instead of a single red LED. All checks are side-effect free.
+ */
+public final class Diagnostics {
+
+    private Diagnostics() {}
+
+    public static List<DiagnosticResult> runAll(AppConfig cfg) {
+        List<DiagnosticResult> results = new ArrayList<>();
+        results.add(checkConfiguration(cfg));
+        results.add(checkWorkbook(cfg));
+        results.add(checkLogsDirectory(cfg));
+        results.add(testWebSocket(cfg));
+        results.add(readStatusFile());
+        return results;
+    }
+
+    public static DiagnosticResult checkConfiguration(AppConfig cfg) {
+        boolean ok = cfg != null
+                && notBlank(cfg.clientId)
+                && notBlank(cfg.authToken)
+                && notBlank(cfg.serverWsUrl)
+                && notBlank(cfg.excelFilePath);
+
+        StringBuilder detail = new StringBuilder();
+        if (cfg == null) {
+            detail.append("Configuration could not be loaded.");
+        } else {
+            append(detail, "Client ID", cfg.clientId);
+            append(detail, "Auth Token", mask(cfg.authToken));
+            append(detail, "Server WS", cfg.serverWsUrl);
+            append(detail, "Excel Path", cfg.excelFilePath);
+        }
+
+        if (!ok) {
+            detail.append("\n⚠️ Missing required fields. Run the installer or Settings tab.");
+        }
+        return new DiagnosticResult("Configuration", ok, detail.toString());
+    }
+
+    public static DiagnosticResult checkWorkbook(AppConfig cfg) {
+        if (cfg == null || !notBlank(cfg.excelFilePath)) {
+            return new DiagnosticResult("Workbook", false, "Excel path not configured.");
+        }
+        Path path = Paths.get(cfg.excelFilePath);
+        boolean exists = Files.exists(path);
+        boolean readable = Files.isReadable(path);
+        boolean writable = Files.isWritable(path);
+        StringBuilder detail = new StringBuilder();
+        detail.append(path.toAbsolutePath());
+        detail.append("\nexists=").append(exists);
+        detail.append(", readable=").append(readable);
+        detail.append(", writable=").append(writable);
+
+        boolean ok = exists && readable && writable;
+        if (!ok) {
+            detail.append("\n⚠️ Fix file permissions or choose a different workbook.");
+        }
+        return new DiagnosticResult("Workbook", ok, detail.toString());
+    }
+
+    public static DiagnosticResult checkLogsDirectory(AppConfig cfg) {
+        Path dir;
+        if (cfg != null && notBlank(cfg.logsDir)) {
+            dir = Paths.get(cfg.logsDir.trim());
+        } else {
+            dir = Paths.get(System.getProperty("user.home"), "apache-bridge", "apachebridge-logs");
+        }
+        try {
+            Files.createDirectories(dir);
+            boolean writable = Files.isWritable(dir);
+            String detail = dir.toAbsolutePath() + "\nwritable=" + writable;
+            return new DiagnosticResult("Logs directory", writable, detail + (writable ? "" : "\n⚠️ Unable to write logs."));
+        } catch (IOException e) {
+            return new DiagnosticResult("Logs directory", false,
+                    dir.toAbsolutePath() + "\nError: " + e.getMessage());
+        }
+    }
+
+    public static DiagnosticResult testWebSocket(AppConfig cfg) {
+        if (cfg == null || !notBlank(cfg.serverWsUrl)) {
+            return new DiagnosticResult("Server connectivity", false, "Server URL not configured.");
+        }
+        URI probe;
+        try {
+            probe = deriveProbeUri(cfg.serverWsUrl.trim());
+        } catch (URISyntaxException e) {
+            return new DiagnosticResult("Server connectivity", false, "Invalid URL: " + e.getMessage());
+        }
+
+        HttpClient client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .build();
+
+        HttpRequest request = HttpRequest.newBuilder(probe)
+                .timeout(Duration.ofSeconds(6))
+                .header("User-Agent", "ApacheBridgeDesktop/diagnostics")
+                .GET()
+                .build();
+
+        try {
+            HttpResponse<Void> response = client.send(request, HttpResponse.BodyHandlers.discarding());
+            int code = response.statusCode();
+            boolean ok = code >= 200 && code < 400;
+            String detail = "HTTP " + code + " from " + probe;
+            if (!ok) detail += "\n⚠️ Unexpected status. Server may be unreachable.";
+            return new DiagnosticResult("Server connectivity", ok, detail);
+        } catch (HttpTimeoutException e) {
+            return new DiagnosticResult("Server connectivity", false, "Timed out contacting " + probe);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return new DiagnosticResult("Server connectivity", false, "Interrupted: " + e.getMessage());
+        } catch (IOException e) {
+            return new DiagnosticResult("Server connectivity", false, e.getClass().getSimpleName() + ": " + e.getMessage());
+        }
+    }
+
+    public static DiagnosticResult readStatusFile() {
+        StatusReporter.Status st = StatusReporter.read();
+        if (st == null) {
+            return new DiagnosticResult("Runtime status", false,
+                    "No status file yet. The desktop client has not reported in.");
+        }
+        boolean ok = st.connected;
+        StringBuilder detail = new StringBuilder();
+        detail.append("connected=").append(st.connected);
+        detail.append(", lastError=").append(st.lastError == null ? "" : st.lastError);
+        long age = Math.max(0, Instant.now().getEpochSecond() - st.epochTs);
+        detail.append("\nlast heartbeat ").append(age).append("s ago");
+        if (!ok) {
+            detail.append("\n⚠️ Investigate logs below.");
+        }
+        return new DiagnosticResult("Runtime status", ok, detail.toString());
+    }
+
+    public static String formatResults(List<DiagnosticResult> results) {
+        StringBuilder sb = new StringBuilder();
+        for (DiagnosticResult r : results) {
+            sb.append(r.ok ? "✅ " : "❌ ");
+            sb.append(r.name).append('\n');
+            if (r.detail != null && !r.detail.isBlank()) {
+                sb.append("    ").append(r.detail.replace("\n", "\n    ")).append('\n');
+            }
+            sb.append('\n');
+        }
+        return sb.toString();
+    }
+
+    private static void append(StringBuilder sb, String label, String value) {
+        if (sb.length() > 0) sb.append('\n');
+        sb.append(label).append(": ").append(value == null ? "(unset)" : value);
+    }
+
+    private static String mask(String token) {
+        if (!notBlank(token)) return "(unset)";
+        if (token.length() <= 4) return "****";
+        return token.substring(0, 2) + "****" + token.substring(token.length() - 2);
+    }
+
+    private static boolean notBlank(String s) {
+        return s != null && !s.trim().isEmpty();
+    }
+
+    private static URI deriveProbeUri(String wsUrl) throws URISyntaxException {
+        URI uri = new URI(wsUrl);
+        String scheme = uri.getScheme();
+        if (scheme == null) throw new URISyntaxException(wsUrl, "Missing scheme");
+        String replacement;
+        switch (scheme.toLowerCase()) {
+            case "wss": replacement = "https"; break;
+            case "ws":  replacement = "http"; break;
+            default:      replacement = scheme; break;
+        }
+        if (replacement.equalsIgnoreCase(scheme)) {
+            return uri;
+        }
+        return new URI(replacement, uri.getUserInfo(), uri.getHost(), uri.getPort(),
+                uri.getPath() == null || uri.getPath().isEmpty() ? "/" : uri.getPath(),
+                uri.getQuery(), uri.getFragment());
+    }
+
+    public static final class DiagnosticResult {
+        public final String name;
+        public final boolean ok;
+        public final String detail;
+
+        public DiagnosticResult(String name, boolean ok, String detail) {
+            this.name = name;
+            this.ok = ok;
+            this.detail = detail;
+        }
+    }
+}

--- a/src/main/java/desk/ServiceController.java
+++ b/src/main/java/desk/ServiceController.java
@@ -1,0 +1,201 @@
+package desk;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Cross-platform helpers to manage the background watchdog + headless service.
+ * Exposed to the GUI so operators can recover without touching the terminal.
+ */
+public final class ServiceController {
+
+    private static final String SERVICE_TOKEN = "desk.ServiceMain";
+    private static final String WATCHDOG_TOKEN = "apachebridge-watchdog";
+
+    private ServiceController() {}
+
+    public static ServiceActionResult startService() {
+        try {
+            AutoStartManager.startNow();
+            return new ServiceActionResult(true, "Watchdog launched in the background.");
+        } catch (Exception e) {
+            return new ServiceActionResult(false, "Failed to launch watchdog: " + e.getMessage());
+        }
+    }
+
+    public static ServiceActionResult stopService() {
+        List<Long> stopped = new ArrayList<>();
+        List<Long> failed = new ArrayList<>();
+
+        ProcessHandle.allProcesses().forEach(ph -> {
+            if (!ph.isAlive()) return;
+            if (matches(ph.info(), SERVICE_TOKEN) || matches(ph.info(), WATCHDOG_TOKEN)) {
+                try {
+                    boolean terminated = attemptStop(ph);
+                    if (terminated) {
+                        stopped.add(ph.pid());
+                    } else {
+                        failed.add(ph.pid());
+                    }
+                } catch (Exception ex) {
+                    failed.add(ph.pid());
+                }
+            }
+        });
+
+        if (stopped.isEmpty() && failed.isEmpty()) {
+            return new ServiceActionResult(false, "No running ServiceMain/watchdog processes were found.");
+        }
+
+        StringBuilder detail = new StringBuilder();
+        if (!stopped.isEmpty()) {
+            detail.append("Stopped ").append(stopped.size()).append(" process(es): ").append(stopped).append('.');
+        }
+        if (!failed.isEmpty()) {
+            if (detail.length() > 0) detail.append(' ');
+            detail.append("Could not stop ").append(failed.size()).append(" process(es): ").append(failed);
+        }
+        return new ServiceActionResult(failed.isEmpty(), detail.toString());
+    }
+
+    public static ServiceActionResult restartService() {
+        ServiceActionResult stop = stopService();
+        if (!stop.success) {
+            return new ServiceActionResult(false, "Restart aborted – " + stop.message);
+        }
+        try {
+            TimeUnit.SECONDS.sleep(1);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        ServiceActionResult start = startService();
+        return new ServiceActionResult(start.success, stop.message + "\n" + start.message);
+    }
+
+    public static ServiceActionResult enableAutostart() {
+        try {
+            AutoStartManager.enable();
+            return new ServiceActionResult(true, "Autostart entries installed.");
+        } catch (Exception e) {
+            return new ServiceActionResult(false, "Enable failed: " + e.getMessage());
+        }
+    }
+
+    public static ServiceActionResult disableAutostart() {
+        try {
+            AutoStartManager.disable();
+            return new ServiceActionResult(true, "Autostart entries removed.");
+        } catch (Exception e) {
+            return new ServiceActionResult(false, "Disable failed: " + e.getMessage());
+        }
+    }
+
+    public static String describeAutostart() {
+        String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+        Path base = baseConfigDir();
+        Path script = os.contains("win")
+                ? base.resolve("apachebridge-watchdog.ps1")
+                : base.resolve("apachebridge-watchdog.sh");
+        boolean scriptExists = Files.exists(script);
+
+        boolean autostartExists;
+        if (os.contains("win")) {
+            Path startup = Paths.get(Optional.ofNullable(System.getenv("APPDATA")).orElse(""),
+                    "Microsoft", "Windows", "Start Menu", "Programs", "Startup",
+                    "apache-bridge-watchdog-launcher.bat");
+            autostartExists = Files.exists(startup);
+        } else if (os.contains("mac")) {
+            Path plist = Paths.get(System.getProperty("user.home"),
+                    "Library", "LaunchAgents", "com.jsfdev.apachebridge.watchdog.plist");
+            autostartExists = Files.exists(plist);
+        } else {
+            Path desktopFile = Paths.get(System.getProperty("user.home"),
+                    ".config", "autostart", "apache-bridge-watchdog.desktop");
+            autostartExists = Files.exists(desktopFile);
+        }
+
+        if (!scriptExists && !autostartExists) {
+            return "Not installed";
+        }
+        if (scriptExists && autostartExists) {
+            return "Enabled";
+        }
+        if (scriptExists) {
+            return "Script ready, autostart missing";
+        }
+        return "Autostart entry exists, script missing";
+    }
+
+    public static Path logsDirectory(AppConfig cfg) {
+        if (cfg != null && cfg.logsDir != null && !cfg.logsDir.isBlank()) {
+            return Paths.get(cfg.logsDir.trim());
+        }
+        return baseConfigDir().resolve("apachebridge-logs");
+    }
+
+    public static Path desktopClientLog(AppConfig cfg) {
+        return logsDirectory(cfg).resolve("desktop-client.log");
+    }
+
+    public static Path watchdogLog(AppConfig cfg) {
+        return logsDirectory(cfg).resolve("watchdog.log");
+    }
+
+    public static Path statusFile() {
+        return baseConfigDir().resolve("status.json");
+    }
+
+    public static Path baseConfigDir() {
+        return Paths.get(System.getProperty("user.home"), "apache-bridge");
+    }
+
+    private static boolean attemptStop(ProcessHandle handle) throws InterruptedException {
+        handle.destroy();
+        if (waitForExit(handle, 2)) return true;
+        handle.destroyForcibly();
+        return waitForExit(handle, 2);
+    }
+
+    private static boolean waitForExit(ProcessHandle handle, long seconds) throws InterruptedException {
+        try {
+            handle.onExit().get(seconds, TimeUnit.SECONDS);
+            return true;
+        } catch (TimeoutException e) {
+            return !handle.isAlive();
+        } catch (ExecutionException e) {
+            return !handle.isAlive();
+        }
+    }
+
+    private static boolean matches(ProcessHandle.Info info, String token) {
+        if (info == null) return false;
+        if (info.commandLine().map(cmd -> cmd.contains(token)).orElse(false)) return true;
+        if (info.command().map(cmd -> cmd.contains(token)).orElse(false)) return true;
+        return info.arguments()
+                .map(args -> {
+                    for (String a : args) {
+                        if (a != null && a.contains(token)) return true;
+                    }
+                    return false;
+                })
+                .orElse(false);
+    }
+
+    public static final class ServiceActionResult {
+        public final boolean success;
+        public final String message;
+
+        public ServiceActionResult(boolean success, String message) {
+            this.success = success;
+            this.message = message;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Force the desktop launcher into headless mode when automation triggers it and extend the watchdog scripts to prevent stray GUI processes while exporting the correct headless environment.
- Append desktop client events to a persistent log file in the configured logs directory.
- Add diagnostics and service-management helpers and surface them in a new dashboard tab with quick actions plus an upgraded log viewer.

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68de9d6aa1548330899a17cfe48a17da